### PR TITLE
fix: proof query

### DIFF
--- a/src/store/modules/sdk.ts
+++ b/src/store/modules/sdk.ts
@@ -244,7 +244,7 @@ const actions = <ActionTree<SDKState, RootState>>{
     await dispatch('registerSigner', destNetwork)
 
     // get proof
-    const res = await fetch(`${s3URL}${origin}_${message.leafIndex.toString()}`)
+    const res = await fetch(`${s3URL}${origin.toLowerCase()}_${message.leafIndex.toString()}`)
     const data = (await res.json()) as any
     console.log('proof: ', data)
 


### PR DESCRIPTION
`milkomedaC1` -> `milkomedac1`