### PR TITLE
fix: account for different cases for fetching proofs

### DIFF
--- a/src/config/config.main.ts
+++ b/src/config/config.main.ts
@@ -225,7 +225,7 @@ export const networks: { [key: string]: NetworkMetadata } = {
     domainID: 25393,
     nativeToken: tokens.milkADA,
     rpcUrl: VUE_APP_MILKOMEDA_RPC!,
-    blockExplorer: 'https://rpc.c1.milkomeda.com:4000',
+    blockExplorer: 'https://explorer-mainnet-cardano-evm.c1.milkomeda.com/',
     icon: wADAIcon,
     confirmationTimeInMinutes: PROD_DEFAULT_CONFIRMATION_TIME_IN_MINUTES,
   },

--- a/src/config/config.main.ts
+++ b/src/config/config.main.ts
@@ -225,7 +225,7 @@ export const networks: { [key: string]: NetworkMetadata } = {
     domainID: 25393,
     nativeToken: tokens.milkADA,
     rpcUrl: VUE_APP_MILKOMEDA_RPC!,
-    blockExplorer: 'https://explorer-mainnet-cardano-evm.c1.milkomeda.com/',
+    blockExplorer: 'https://explorer-mainnet-cardano-evm.c1.milkomeda.com',
     icon: wADAIcon,
     confirmationTimeInMinutes: PROD_DEFAULT_CONFIRMATION_TIME_IN_MINUTES,
   },

--- a/src/store/modules/sdk.ts
+++ b/src/store/modules/sdk.ts
@@ -244,7 +244,13 @@ const actions = <ActionTree<SDKState, RootState>>{
     await dispatch('registerSigner', destNetwork)
 
     // get proof
-    const res = await fetch(`${s3URL}${origin.toLowerCase()}_${message.leafIndex.toString()}`)
+    let res
+    try {
+      res = await fetch(`${s3URL}${origin}_${message.leafIndex.toString()}`)
+    } catch(e) {
+      res = await fetch(`${s3URL}${origin.toLowerCase()}_${message.leafIndex.toString()}`)
+    }
+    if (!res) throw new Error('Not able to fetch proof')
     const data = (await res.json()) as any
     console.log('proof: ', data)
 


### PR DESCRIPTION
We likely have outstanding txs that use both camel case and lower case proofs.  Will account for both for now and phase out the old casing later.