### PR TITLE
fix: better copy for processing gas disclaimer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This change log is manually updated at the moment.
 - fix bug in tx detail page where tx was not yet available from indexer
 - bump SDK for new dev deploy
 - add configuration package, add Evmos Testnet
+- update copy for process gas disclaimer
 
 ## v1.4.1 (Apr 19th, 2022)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bridge-web-app",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "private": true,
   "scripts": {
     "build": "vue-cli-service build --mode debug",

--- a/src/views/Transaction/Nomad/Header.vue
+++ b/src/views/Transaction/Nomad/Header.vue
@@ -11,9 +11,7 @@
         <alert-circle-outline />
       </n-icon>
     </template>
-    Reducing the gas limit on a process transaction may result in a failed
-    transaction. By design, the gas limit must be estimated much higher. In
-    reality, the gas price will be aproximately 1/5 the estimate.
+    Processing gas fees will be approximately 80% cheaper than estimated. Reducing the gas limit may result in a failed transaction.
     <a
       href="https://docs.nomad.xyz/bridge/faq.html#why-is-gas-estimate-so-high-to-get-my-funds-on-ethereum"
       target="_blank"

--- a/src/views/Transaction/Nomad/Header.vue
+++ b/src/views/Transaction/Nomad/Header.vue
@@ -11,7 +11,8 @@
         <alert-circle-outline />
       </n-icon>
     </template>
-    Processing gas fees will be approximately 80% cheaper than estimated. Reducing the gas limit may result in a failed transaction.
+    Processing gas fees will be approximately 80% cheaper than estimated.
+    Reducing the gas limit may result in a failed transaction.
     <a
       href="https://docs.nomad.xyz/bridge/faq.html#why-is-gas-estimate-so-high-to-get-my-funds-on-ethereum"
       target="_blank"


### PR DESCRIPTION
Old copy was long-winded and not very clear. Also was kind of backwards, with the important part at the end (aka this doesn't cost nearly this much)