### PR TITLE
add: add network error message

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -20,7 +20,9 @@ export const config = configuration.getBuiltin(environment)
 export const isProduction = environment === 'production'
 export const tokens = isProduction ? mainnetTokens : testnetTokens
 export const networks = getNetworksFromConfig(config, tokens)
-export const connextConfig = getConnextConfigFromConfig(config, [VUE_APP_ETHEREUM_RPC])
+export const connextConfig = getConnextConfigFromConfig(config, [
+  VUE_APP_ETHEREUM_RPC,
+])
 export const proofsS3 = VUE_APP_PROOFS_S3
 export const connextScanURL = VUE_APP_CONNEXTSCAN_URL
 export const nomadAPI = VUE_APP_NOMAD_API

--- a/src/store/modules/sdk.ts
+++ b/src/store/modules/sdk.ts
@@ -287,10 +287,11 @@ const getters = <GetterTree<SDKState, RootState>>{
       return message
     },
 
-  getTimestamp: () => async (destDomain: string | number, blockNumber: number) => {
-    const provider = nomad.mustGetProvider(destDomain)
-    return (await provider.getBlock(blockNumber)).timestamp
-  },
+  getTimestamp:
+    () => async (destDomain: string | number, blockNumber: number) => {
+      const provider = nomad.mustGetProvider(destDomain)
+      return (await provider.getBlock(blockNumber)).timestamp
+    },
 
   resolveDomain: () => (network: string) => {
     return nomad.resolveDomain(network)

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -84,7 +84,7 @@ export function toDecimals(
  * @param timestamp Given a confirmAt timestamp, calculate how many minutes until
  * @returns number
  */
- export function minutesTilConfirmation(timestamp: BigNumber): number {
+export function minutesTilConfirmation(timestamp: BigNumber): number {
   const now = BigNumber.from(Date.now()).div(1000)
   const diff = timestamp.sub(now)
   if (diff.lt(0)) return 0

--- a/src/views/Transaction/Nomad/Details.vue
+++ b/src/views/Transaction/Nomad/Details.vue
@@ -148,7 +148,8 @@ export default defineComponent({
     if (!message) {
       this.notification.error({
         title: 'Invalid URL',
-        description: 'Please check that the url has the correct network and transaction ID',
+        description:
+          'Please check that the url has the correct network and transaction ID',
       })
       throw new Error('Unable to fetch transaction details')
     }
@@ -197,25 +198,32 @@ export default defineComponent({
       if (!network || !id) {
         this.notification.error({
           title: 'Incomplete URL',
-          description: 'Please add the origin network and ID of your transaction',
+          description:
+            'Please add the origin network and ID of your transaction',
         })
-        throw new Error('Incomplete transaction URL, can\'t fetch transaction details')
+        throw new Error(
+          "Incomplete transaction URL, can't fetch transaction details"
+        )
       }
       if (id.length !== 66) {
         this.notification.error({
           title: 'Invalid Transaction',
           description: 'Please check that you have the correct transaction ID',
         })
-        throw new Error('Invalid transaction ID, can\'t fetch transaction details')
+        throw new Error(
+          "Invalid transaction ID, can't fetch transaction details"
+        )
       }
       try {
         toNetworkName(network as string)
-      } catch(e) {
+      } catch (e) {
         this.notification.error({
           title: 'Invalid Network Name',
           description: 'Please check that you have the correct network',
         })
-        throw new Error('Invalid network param, can\'t fetch transaction details')
+        throw new Error(
+          "Invalid network param, can't fetch transaction details"
+        )
       }
     },
     async addToken() {
@@ -274,7 +282,10 @@ export default defineComponent({
             return
           }
 
-          const relayedAt = await this.store.getters.getTimestamp(message.destination, relayed.event.blockNumber)
+          const relayedAt = await this.store.getters.getTimestamp(
+            message.destination,
+            relayed.event.blockNumber
+          )
           this.confirmAt = BigNumber.from(relayedAt + optimisticSeconds)
         }
 

--- a/src/views/Transaction/Nomad/Header.vue
+++ b/src/views/Transaction/Nomad/Header.vue
@@ -214,11 +214,12 @@ export default defineComponent({
     ChevronDown,
     AlertCircleOutline,
   },
-  data: () => ({
-    PROCESS_TIME_IN_MINUTES,
-    showStatus: false,
-    now: Date.now()
-  } as ComponentData),
+  data: () =>
+    ({
+      PROCESS_TIME_IN_MINUTES,
+      showStatus: false,
+      now: Date.now(),
+    } as ComponentData),
   setup: () => {
     const store = useStore()
     const notification = useNotification()

--- a/src/views/Transfer/Input/Input.networks.vue
+++ b/src/views/Transfer/Input/Input.networks.vue
@@ -36,7 +36,7 @@
 
 <script lang="ts">
 import { computed, defineComponent } from 'vue'
-import { NModal, NCard, NText, NButton } from 'naive-ui'
+import { NModal, NCard, NText, NButton, useNotification } from 'naive-ui'
 import { NetworkMetadata } from '@/config/types'
 import { useStore } from '@/store'
 
@@ -60,6 +60,7 @@ export default defineComponent({
 
   setup(props) {
     const store = useStore()
+    const notification = useNotification()
 
     return {
       networks: computed(() => store.getters.activeNetworks()),
@@ -69,6 +70,7 @@ export default defineComponent({
           : 'SELECT ORIGIN'
       }),
       store,
+      notification,
     }
   },
 
@@ -80,7 +82,7 @@ export default defineComponent({
   },
 
   methods: {
-    select(network: NetworkMetadata) {
+    async select(network: NetworkMetadata) {
       const isUnavailable = this.unavailable(network)
       if (this.isSelectingDestination) {
         if (isUnavailable) {
@@ -91,7 +93,14 @@ export default defineComponent({
         if (isUnavailable) {
           this.store.dispatch('setDestinationNetwork', null)
         }
-        this.store.dispatch('switchNetwork', network.name)
+        try {
+          await this.store.dispatch('switchNetwork', network.name)
+        } catch (e) {
+          this.notification.error({
+            title: 'Error switching network',
+            description: 'Have you added the network in Metamask?',
+          })
+        }
       }
       this.$emit('hide')
     },


### PR DESCRIPTION
Chain ID for evmos isn't recognized when calling `wallet_addEthereumChain`, so user can't select chain.  Show error so users know what to do about it