### PR TITLE
fix: various network switching bug fixes

### DIFF
--- a/src/store/modules/userInput.ts
+++ b/src/store/modules/userInput.ts
@@ -90,10 +90,11 @@ const actions = <ActionTree<UserInputState, RootState>>{
     commit(types.SET_ORIGIN_NETWORK, network)
 
     // clear destination network if there is not a connection
-    const { connections } = networks[network]
-    const hasConnection = connections.includes(
-      state.destinationNetwork as NetworkName
-    )
+    const hasConnection = network
+      ? networks[network]?.connections?.includes(
+          state.destinationNetwork as NetworkName
+        )
+      : false
     if (!hasConnection) commit(types.SET_DESTINATION_NETWORK, '')
 
     try {

--- a/src/store/modules/wallet.ts
+++ b/src/store/modules/wallet.ts
@@ -156,7 +156,7 @@ const actions = <ActionTree<WalletState, RootState>>{
   },
 
   async switchNetwork({ dispatch, state }, networkName: string) {
-    console.log('set wallet network')
+    console.log('set wallet network', networkName)
     if (!state.connected) {
       await dispatch('connectWallet')
     }
@@ -168,7 +168,11 @@ const actions = <ActionTree<WalletState, RootState>>{
     const hexChainId = '0x' + network.chainID.toString(16)
 
     // if wallet is already on correct chain, return
-    if (connection.chainId == hexChainId) return
+    if (connection.chainId == hexChainId) {
+      // set the origin network in case it is null when selecting an unavailable network
+      dispatch('setOriginNetwork', networkName)
+      return
+    }
 
     // switch chains
     try {
@@ -176,6 +180,7 @@ const actions = <ActionTree<WalletState, RootState>>{
         method: 'wallet_switchEthereumChain',
         params: [{ chainId: hexChainId }],
       })
+      dispatch('setWalletNetwork', networkName)
     } catch (switchError: unknown) {
       // This error code indicates that the chain has not been added to their wallet.
       if ((switchError as ProviderRpcError).code === 4902) {
@@ -198,8 +203,6 @@ const actions = <ActionTree<WalletState, RootState>>{
         throw switchError
       }
     }
-
-    dispatch('setWalletNetwork', network.name)
   },
 
   async addToken({ dispatch, state, rootGetters }, payload: TokenPayload) {

--- a/src/store/modules/wallet.ts
+++ b/src/store/modules/wallet.ts
@@ -199,6 +199,7 @@ const actions = <ActionTree<WalletState, RootState>>{
             },
           ],
         })
+        dispatch('setWalletNetwork', network.name)
       } else {
         throw switchError
       }

--- a/src/views/Transfer/Input/Input.networks.vue
+++ b/src/views/Transfer/Input/Input.networks.vue
@@ -91,12 +91,14 @@ export default defineComponent({
         }
         this.store.dispatch('setDestinationNetwork', network.name)
       } else {
-        if (isUnavailable) {
-          this.store.dispatch('setDestinationNetwork', null)
-        }
         try {
           await this.store.dispatch('switchNetwork', network.name)
+          // set destination network to null if switch network was successful
+          if (isUnavailable) {
+            this.store.dispatch('setDestinationNetwork', null)
+          }
         } catch (e) {
+          // TODO: provide a better error message when user rejects the network change (code: 4001)
           this.notification.warning({
             title: 'Error switching network',
             content: () =>
@@ -105,6 +107,8 @@ export default defineComponent({
                 error: e as Error,
               }),
           })
+          // close select origin modal if there was an error switching network
+          this.$emit('hide')
           throw e
         }
       }

--- a/src/views/Transfer/Input/Input.tokens.vue
+++ b/src/views/Transfer/Input/Input.tokens.vue
@@ -103,8 +103,12 @@ export default defineComponent({
     },
 
     async switchAndSelect(token: TokenMetadata) {
-      await this.store.dispatch('switchNetwork', token.nativeNetwork)
-      this.select(token)
+      try {
+        await this.store.dispatch('switchNetwork', token.nativeNetwork)
+        this.select(token)
+      } catch (e: unknown) {
+        this.$emit('hide')
+      }
     },
   },
 })


### PR DESCRIPTION
Fixes the following:
- connection undefined bug thrown in sentry when origin network is being set to null
- add network name to console.log when switching network to help debug in sentry
- set the origin network if the connection is correct to keep app state in sync
- only set wallet network if switching the chain was successful
- only set destination network to null if unavailable if switching chain was successful
- hide switch network modal even if switching chain was unsuccessful
- hide select token modal on error of switching chain for that token

