### PR TITLE
fix: don't alert to sentry when user closes the wallet connect modal

### DIFF
--- a/src/store/modules/wallet.ts
+++ b/src/store/modules/wallet.ts
@@ -85,7 +85,15 @@ const actions = <ActionTree<WalletState, RootState>>{
       },
     })
 
-    connection = await web3Modal.connect()
+    try {
+      connection = await web3Modal.connect()
+    } catch (e: unknown) {
+      // NOTE: just swallow this error, don't need to
+      // alert sentry if the modal was closed by the user
+      if (e === 'Modal closed by user') {
+        return
+      }
+    }
     web3 = new providers.Web3Provider(connection, 'any')
     const signer = web3.getSigner()
 

--- a/src/store/modules/wallet.ts
+++ b/src/store/modules/wallet.ts
@@ -87,10 +87,10 @@ const actions = <ActionTree<WalletState, RootState>>{
 
     try {
       connection = await web3Modal.connect()
-    } catch (e: unknown) {
+    } catch (errMsg: unknown) {
       // NOTE: just swallow this error, don't need to
       // alert sentry if the modal was closed by the user
-      if (e === 'Modal closed by user') {
+      if (errMsg === 'Modal closed by user') {
         return
       }
     }


### PR DESCRIPTION
Surprised there was no way to silence this error (https://github.com/Web3Modal/web3modal/blob/master/src/core/index.tsx#L780