### PR TITLE
fix: allow user to try to process their tx if status is not available

### DIFF
--- a/src/store/modules/sdk.ts
+++ b/src/store/modules/sdk.ts
@@ -235,6 +235,11 @@ const actions = <ActionTree<SDKState, RootState>>{
     replica.connect(signer)
 
     try {
+      await replica.callStatic.proveAndProcess(
+        data.message as BytesLike,
+        data.proof.path,
+        data.proof.index
+      )
       // prove and process
       const receipt = await replica.proveAndProcess(
         data.message as BytesLike,

--- a/src/views/Transaction/Nomad/Details.vue
+++ b/src/views/Transaction/Nomad/Details.vue
@@ -183,7 +183,6 @@ export default defineComponent({
     try {
       await this.updateStatus()
     } catch (e) {
-      this.status = 0
       console.error(e)
     }
 
@@ -270,34 +269,6 @@ export default defineComponent({
         }
         // set status after we have confirmAt
         this.status = tx.state
-      } else {
-        const message: TransferMessage = await this.store.getters.getTxMessage({
-          network: toNetworkName(this.originNet),
-          hash: id,
-        })
-
-        const processed = await message.getProcess()
-        if (processed) {
-          this.status = 4
-          return
-        }
-
-        if (!this.confirmAt) {
-          const relayed = await message.getReplicaUpdate()
-          if (!relayed) {
-            this.status = 0
-            return
-          }
-
-          const relayedAt = await this.store.getters.getTimestamp(
-            message.destination,
-            relayed.event.blockNumber
-          )
-          this.confirmAt = BigNumber.from(relayedAt + optimisticSeconds)
-        }
-
-        // set status after we have confirmAt
-        this.status = 2
       }
     },
   },

--- a/src/views/Transaction/Nomad/Header.vue
+++ b/src/views/Transaction/Nomad/Header.vue
@@ -77,6 +77,26 @@
       <img src="@/assets/icons/check.svg" alt="check" class="mb-2" />
       <n-text class="uppercase opacity-80">Transfer complete</n-text>
     </span>
+    <!-- status not available, subsidized network -->
+    <span class="flex flex-col items-center" v-else-if="status === -1 && !requiresManualProcessing">
+      <n-text class="text-3xl mb-2">Status not available</n-text>
+      <n-text class="opacity-80 text-center">Check your wallet after the 35-60 minute window to see if funds have arrived.</n-text>
+    </span>
+    <!-- status not available, subsidized network -->
+    <span class="flex flex-col items-center" v-else-if="status === -1 && requiresManualProcessing">
+      <n-text class="text-3xl mb-2">Status not available</n-text>
+      <n-text class="opacity-80 text-center mb-2">You may safely try to complete your transaction by clicking below. Note that you should wait at least 35 minutes after your transfer was sent.</n-text>
+      <n-text @click="processTx" class="uppercase mt-1 cursor-pointer p-2">
+        <span class="click-me flex flex-row items-center">
+          Complete transfer
+          <img
+            src="@/assets/icons/arrow-right-up.svg"
+            alt="open"
+            class="ml-2 cursor-pointer"
+          />
+        </span>
+      </n-text>
+    </span>
     <!-- Manual process -->
     <span
       class="flex flex-col items-center max-w-xs"


### PR DESCRIPTION
 - Removes event querying via sdk (wasn't working anyway)
 - Handles the case where we may not have status available or the indexer may be down
 - _Safely_ allows users to try to process their transaction at any time if status is not available

<img width="626" alt="Screen Shot 2022-05-20 at 9 47 51 AM" src="https://user-images.githubusercontent.com/36751902/169565617-6f6677dd-0691-4121-a7bb-66084512e26c.png">
