### PR TITLE
fix: copy/paste firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This change log is manually updated at the moment.
 
 ## Unreleased
 
+- fix copy/paste in Firefox
+
 ## v1.5.0 (May 19th, 2022)
 
 - Wallet Connect

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bridge-web-app",
-  "version": "1.5.1",
+  "version": "1.5.0",
   "private": true,
   "description": "Token Bridge UI",
   "license": "Apache 2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bridge-web-app",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "private": true,
   "description": "Token Bridge UI",
   "license": "Apache 2.0",

--- a/src/AppWrapper.vue
+++ b/src/AppWrapper.vue
@@ -73,7 +73,7 @@ input::-webkit-inner-spin-button
 
 // Hide default input number styles from firefox browser
 input[type=number]
-  -moz-appearance:textfield
+  -moz-appearance textfield !important
 
 //
 // NAIVE UI STYLE OVERRIDES

--- a/src/components/CopyHash.vue
+++ b/src/components/CopyHash.vue
@@ -23,7 +23,7 @@
 <script lang="ts">
 import { computed, defineComponent } from 'vue'
 import { NTooltip, NText } from 'naive-ui'
-import { truncateAddr } from '@/utils'
+import { truncateAddr, copyTextToClipboard } from '@/utils'
 
 export default defineComponent({
   props: {
@@ -52,15 +52,8 @@ export default defineComponent({
         this.copyText = 'error'
         return
       }
-      navigator.clipboard.writeText(this.address).then(
-        () => {
-          console.log('Async: Copying to clipboard was successful!')
-          this.copyText = 'copied'
-        },
-        (err) => {
-          console.error('Async: Could not copy text: ', err)
-        }
-      )
+      const success = copyTextToClipboard(this.address)
+      if (success) this.copyText = 'copied'
     },
     reset() {
       setTimeout(() => (this.copyText = 'copy'), 500)

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -138,7 +138,7 @@ export function copyTextToClipboard(text: string): boolean {
       return true
     }, function(err) {
       console.error('Async: Could not copy text: ', err)
-      return false
+      return fallbackCopyTextToClipboard(text)
     })
   }
   return fallbackCopyTextToClipboard(text)

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -60,6 +60,12 @@ export function fromBytes32(addr: string): string {
   return `0x${short}`
 }
 
+export function toBytes32(addr: string): string {
+  // trim 12 bytes from beginning plus '0x'
+  const short = addr.slice(2)
+  return `0x000000000000000000000000${short}`
+}
+
 /**
  * Makes a BigNumber have # of decimals
  */
@@ -97,6 +103,53 @@ export function minutesTilConfirmation(timestamp: BigNumber): number {
   // to minutes
   const minutes = diff.div(60)
   return Math.ceil(minutes.toNumber())
+}
+
+function fallbackCopyTextToClipboard(text: string): boolean {
+  const textArea = document.createElement("textarea")
+  textArea.value = text
+
+  // Avoid scrolling to bottom
+  textArea.style.top = "0"
+  textArea.style.left = "0"
+  textArea.style.position = "fixed"
+
+  document.body.appendChild(textArea)
+  textArea.focus()
+  textArea.select()
+
+  try {
+    const successful = document.execCommand('copy')
+    const msg = successful ? 'successful' : 'unsuccessful'
+    console.log('Fallback: Copying text command was ' + msg)
+    document.body.removeChild(textArea)
+    return true
+  } catch (err) {
+    console.error('Fallback: Oops, unable to copy', err)
+    document.body.removeChild(textArea)
+    return false
+  }
+}
+
+export function copyTextToClipboard(text: string): boolean {
+  if (navigator.clipboard) {
+    navigator.clipboard.writeText(text).then(function() {
+      console.log('Async: Copying to clipboard was successful!')
+      return true
+    }, function(err) {
+      console.error('Async: Could not copy text: ', err)
+      return false
+    })
+  }
+  return fallbackCopyTextToClipboard(text)
+}
+
+export async function pasteFromClipboard(): Promise<string> {
+  if (navigator.clipboard && navigator.clipboard.readText) {
+    console.log('hi')
+    return await navigator.clipboard.readText()
+  }
+  throw new Error('paste action not supported')
 }
 
 // NETWORK

--- a/src/views/Transfer/Review/Review.main.vue
+++ b/src/views/Transfer/Review/Review.main.vue
@@ -16,7 +16,7 @@
       <protocol
         :selected="protocol === 'nomad'"
         name="nomad"
-        time="30-65 min"
+        time="35-60 min"
         description="Bridges funds from one chain to another"
         fee="No fee, just pay gas"
         @click="protocol = 'nomad'"


### PR DESCRIPTION
Closes #313 

 - Fixes copy/paste functionality for firefox (or where navigator clipboard API is not supported)
 - Fixes time estimation typo from 30-65 minutes to 35-60 minutes
 - Hides ugly number input increment button