### PR TITLE
fix: tweak transferstep type, block network switching on review step

### DIFF
--- a/src/store/modules/userInput.ts
+++ b/src/store/modules/userInput.ts
@@ -11,7 +11,10 @@ import { networks } from '@/config'
 import { TokenMetadata, NetworkName } from '@/config/types'
 import { nullToken } from '@/utils'
 
-type TransferStep = 1 | 2
+export enum TransferStep {
+  INPUT = 1,
+  REVIEW,
+}
 
 export interface UserInputState {
   step: TransferStep

--- a/src/store/modules/wallet.ts
+++ b/src/store/modules/wallet.ts
@@ -12,6 +12,7 @@ import { TokenIdentifier } from '@nomad-xyz/sdk-bridge'
 import { NetworkName } from '@/config/types'
 import Web3Modal from 'web3modal'
 import WalletConnectProvider from '@walletconnect/web3-provider'
+import { TransferStep } from '@/store/modules/userInput'
 
 let connection: any // instance of web3Modal connection
 let web3: any // instance of ethers web3Provider
@@ -52,7 +53,7 @@ const mutations = <MutationTree<WalletState>>{
 }
 
 const actions = <ActionTree<WalletState, RootState>>{
-  async connectWallet({ dispatch, commit, state }) {
+  async connectWallet({ dispatch, commit, state, rootState }) {
     console.log('connecting wallet')
 
     // check if already connected
@@ -107,6 +108,9 @@ const actions = <ActionTree<WalletState, RootState>>{
       }
     })
     connection.on('chainChanged', async (chainId: number) => {
+      if (rootState.userInput.step === TransferStep.REVIEW) {
+        return // don't update network in the store when on the review step
+      }
       console.log('network change', chainId)
       // get name of network and set in store
       const id = BigNumber.from(chainId).toNumber()

--- a/src/views/Transfer/Input/Input.main.vue
+++ b/src/views/Transfer/Input/Input.main.vue
@@ -30,16 +30,15 @@ import { useVuelidate } from '@vuelidate/core'
 import { useStore } from '@/store'
 
 import BgBlur from './Input.bgblur.vue'
-import TransferSteps from '../Transfer.steps.vue'
 import TransferAmount from './Input.amount.vue'
 import TransferInputs from './Input.inputs.vue'
 import NomadButton from '@/components/Button.vue'
 import { useNotification } from 'naive-ui'
+import { TransferStep } from '@/store/modules/userInput'
 
 export default defineComponent({
   components: {
     BgBlur,
-    TransferSteps,
     TransferAmount,
     TransferInputs,
     NomadButton,
@@ -69,12 +68,13 @@ export default defineComponent({
       // return if HBOT criteria is not met
       if (token.symbol === 'HBOT') {
         const networks = [originNetwork, destinationNetwork]
-        const hasAvalanche = networks.some(n => n === 'avalanche')
-        const hasEthereum = networks.some(n => n === 'ethereum')
+        const hasAvalanche = networks.some((n) => n === 'avalanche')
+        const hasEthereum = networks.some((n) => n === 'ethereum')
         if (!hasAvalanche || !hasEthereum) {
           this.notification.warning({
             title: 'Action not supported',
-            description: 'HBOT token may only be sent between Avalanche and Ethereum',
+            description:
+              'HBOT token may only be sent between Avalanche and Ethereum',
             duration: 10000,
           })
           return
@@ -82,7 +82,7 @@ export default defineComponent({
       }
       const valid = await this.v$.$validate()
       if (valid) {
-        this.store.dispatch('setTransferStep', 2)
+        this.store.dispatch('setTransferStep', TransferStep.REVIEW)
       }
     },
   },

--- a/src/views/Transfer/Review/Review.main.vue
+++ b/src/views/Transfer/Review/Review.main.vue
@@ -153,6 +153,7 @@ import TransferPending from '../Transfer.pending.vue'
 import Protocol from './Review.protocol.vue'
 import ReviewDetail from './Review.detail.vue'
 import ReviewSend from './Review.send.vue'
+import { TransferStep } from '@/store/modules/userInput'
 
 export default defineComponent({
   components: {
@@ -234,7 +235,7 @@ export default defineComponent({
     back() {
       if (this.sending || this.preparingSwap) return
       this.store.dispatch('resetTransferQuote')
-      this.store.dispatch('setTransferStep', 1)
+      this.store.dispatch('setTransferStep', TransferStep.INPUT)
     },
   },
   computed: {

--- a/src/views/Transfer/Review/Review.send.vue
+++ b/src/views/Transfer/Review/Review.send.vue
@@ -70,6 +70,7 @@ import NotificationLink from '@/components/NotificationLink.vue'
 import NotificationError from '@/components/NotificationError.vue'
 import { networks, connextScanURL } from '@/config'
 import { isNativeToken, getNetworkDomainIDByName } from '@/utils'
+import { TransferStep } from '@/store/modules/userInput'
 
 export default defineComponent({
   props: {
@@ -106,7 +107,7 @@ export default defineComponent({
       }
       // clear user input and switch back to input screen
       this.store.dispatch('clearInputs')
-      this.store.dispatch('setTransferStep', 1)
+      this.store.dispatch('setTransferStep', TransferStep.INPUT)
     },
     async bridge() {
       const {


### PR DESCRIPTION
Fixes error in sentry (`Cannot read properties of undefined (reading 'manualProcessing')`) that occurs when a user switches the network during the review step.