### PR TITLE
Erinhales/only hbot

### DIFF
--- a/src/views/Transfer/Input/Input.main.vue
+++ b/src/views/Transfer/Input/Input.main.vue
@@ -80,6 +80,16 @@ export default defineComponent({
           return
         }
       }
+      // only allow HBOT to Avalanche
+      if (destinationNetwork === 'avalanche' && token.symbol !== 'HBOT') {
+        this.notification.warning({
+          title: 'Action not supported',
+          description:
+            'HBOT is the only Nomad asset currently supported on Avalanche',
+          duration: 10000,
+        })
+        return
+      }
       const valid = await this.v$.$validate()
       if (valid) {
         this.store.dispatch('setTransferStep', TransferStep.REVIEW)

--- a/src/views/Transfer/Input/Input.tokens.vue
+++ b/src/views/Transfer/Input/Input.tokens.vue
@@ -11,7 +11,7 @@
       <!-- token list -->
       <div class="tokens-container">
         <div
-          v-for="token in tokens"
+          v-for="token in tokensFilter"
           :key="token.symbol"
           class="flex flex-row items-center justify-between p-2 cursor-pointer rounded-lg hover:bg-white hover:bg-opacity-5"
           :class="{ disabled: shouldSwitchToNative(token) }"
@@ -111,6 +111,15 @@ export default defineComponent({
       }
     },
   },
+
+  computed: {
+    tokensFilter() {
+      if (this.store.state.userInput.destinationNetwork === 'avalanche') {
+        return this.tokens.filter(t => t.symbol === 'HBOT')
+      }
+      return this.tokens
+    }
+  }
 })
 </script>
 


### PR DESCRIPTION
 - Error notification if user selected token that's not supported
 - If user has selected avalanche as destination, only show HBOT in token modal

<img width="915" alt="Screen Shot 2022-06-12 at 7 25 02 AM" src="https://user-images.githubusercontent.com/36751902/173235477-519589d8-21d2-4de0-953e-105fa4777758.png">
<img width="915" alt="Screen Shot 2022-06-12 at 7 25 13 AM" src="https://user-images.githubusercontent.com/36751902/173235480-d857afde-ffdd-48dc-b384-256d09b8d4b6.png">
