### PR TITLE
fix: avalanche native token

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -17,7 +17,9 @@ const environment = VUE_APP_NOMAD_ENVIRONMENT
 
 const configuration = await import('@nomad-xyz/configuration')
 const conf = configuration.getBuiltin(environment)
-conf.bridgeGui.ethereum.connections?.push('evmos')
+if (conf.bridgeGui.ethereum) {
+  conf.bridgeGui.ethereum.connections?.push('evmos')
+}
 export const config = conf
 
 export const isProduction = environment === 'production'

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,6 +1,7 @@
 import { SdkBaseChainConfigParams } from '@connext/nxtp-sdk'
 import { NomadConfig } from '@nomad-xyz/configuration'
 import { NetworkMetadata, NetworkMap, TokenMetadataMap } from '@/config/types'
+import AVAXIcon from '@/assets/token-logos/AVAX.png'
 
 const {
   VUE_APP_ETHEREUM_RPC,
@@ -96,6 +97,11 @@ export const getNetworksFromConfig = (
       optimisticSeconds,
     } as NetworkMetadata
   })
+
+  // Add avalanche icon because it doesn't have native asset listed
+  if (networks.avalanche) {
+    networks.avalanche.icon = AVAXIcon
+  }
 
   return networks
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -227,6 +227,7 @@ export function getTokenBySymbol(symbol: string): TokenMetadata {
 // determines if the token is native to the selected origin network
 export function isNativeToken(network: string, token: TokenMetadata): boolean {
   const nativeToken = networks[network].nativeToken
+  if (!nativeToken) return false
   return nativeToken.symbol === token.symbol
 }
 

--- a/src/views/Transfer/Review/Review.main.vue
+++ b/src/views/Transfer/Review/Review.main.vue
@@ -202,7 +202,7 @@ export default defineComponent({
   methods: {
     truncateAddr,
     nativeAssetSymbol(network: NetworkName) {
-      return networks[network].nativeToken.symbol
+      return networks[network].icon
     },
     receiveAssetSymbol() {
       const { token } = this.userInput

--- a/src/views/Transfer/Review/Review.main.vue
+++ b/src/views/Transfer/Review/Review.main.vue
@@ -202,7 +202,13 @@ export default defineComponent({
   methods: {
     truncateAddr,
     nativeAssetSymbol(network: NetworkName) {
-      return networks[network].icon
+      if (network === 'avalanche') {
+        return 'AVAX'
+      }
+      if (!networks[network].nativeToken) {
+        return ''
+      }
+      return networks[network].nativeToken.symbol
     },
     receiveAssetSymbol() {
       const { token } = this.userInput


### PR DESCRIPTION
UI was designed around the assumption that the nativeToken would be listed. When we removed avax, it caused some other side affects (missing network icon).  Another user complained about not being able to send USDC back from avalanche, I think this could be due to the isNativeToken check erroring.