### PR TITLE
add: graphql functions, use for tx status

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -2,6 +2,6 @@ NODE_ENV=development
 VUE_APP_NOMAD_ENVIRONMENT=development
 VUE_APP_SENTRY_DSN=
 VUE_APP_PROOFS_S3=https://nomadxyz-development-proofs.s3.us-west-2.amazonaws.com/
-VUE_APP_NOMAD_API=https://bridge-indexer.dev.madlads.tools/tx/
+VUE_APP_NOMAD_API=https://bridge-indexer.dev.madlads.tools/
 VUE_APP_CONNEXTSCAN_URL=https://testnet.connextscan.io/
 VUE_APP_TERMS_AGREEMENTS=https://service-agreement-api.dev.madlads.tools/

--- a/.env.production
+++ b/.env.production
@@ -2,6 +2,6 @@ NODE_ENV=production
 VUE_APP_NOMAD_ENVIRONMENT=production
 VUE_APP_SENTRY_DSN=https://404a864c31084247ac26e93b5fbf8764@o1081954.ingest.sentry.io/6139473
 VUE_APP_PROOFS_S3=https://nomadxyz-production-proofs.s3.us-west-2.amazonaws.com/
-VUE_APP_NOMAD_API=https://bridge-indexer.prod.madlads.tools/tx/
+VUE_APP_NOMAD_API=https://bridge-indexer.prod.madlads.tools/
 VUE_APP_CONNEXTSCAN_URL=https://connextscan.io/
 VUE_APP_TERMS_AGREEMENTS=https://service-agreement-api.prod.madlads.tools/

--- a/src/utils/nomadAPI.ts
+++ b/src/utils/nomadAPI.ts
@@ -1,0 +1,148 @@
+import { request, gql } from 'graphql-request'
+import { nomadAPI } from '@/config'
+
+export type IndexerTx = {
+  origin: number
+  destination: number
+  leafIndex: string
+  sender: string
+  state: number
+  dispatchedAt: number
+  updatedAt: number
+  relayedAt: number
+  processedAt: number
+  receivedAt: number
+  tx: string
+  amount: string
+  tokenDomain: number
+  tokenId: string
+  confirmAt: number
+}
+
+export async function getUserHistory(
+  address: string,
+  page: number,
+  size: number
+): Promise<Array<IndexerTx>> {
+  const skip = size * (page - 1)
+  const variables = JSON.stringify({
+    where: {
+      OR: [
+        {
+          recipient: {
+            equals: address,
+          },
+          sender: {
+            equals: address,
+          },
+        },
+      ],
+    },
+  })
+  const query = gql`
+    query Query($where: MessagesWhereInput) {
+      findManyMessages(where: $where, take: ${size}, skip: ${skip}) {
+        id
+        messageHash
+        origin
+        destination
+        nonce
+        internalSender
+        internalRecipient
+        msgType
+        root
+        state
+        dispatchBlock
+        dispatchedAt
+        updatedAt
+        relayedAt
+        receivedAt
+        processedAt
+        confirmAt
+        sender
+        recipient
+        amount
+        allowFast
+        detailsHash
+        tokenDomain
+        tokenId
+        body
+        leafIndex
+        tx
+        gasAtDispatch
+        gasAtUpdate
+        gasAtRelay
+        gasAtReceive
+        gasAtProcess
+        sent
+        updated
+        relayed
+        received
+        processed
+        createdAt
+      }
+    }`
+  return await request(`${nomadAPI}graphql`, query, variables).then(
+    (res) => res.findManyMessages
+  )
+}
+
+export async function getTx(txID: string): Promise<IndexerTx> {
+  const variables = JSON.stringify({
+    where: {
+      tx: {
+        equals: txID,
+      },
+    },
+  })
+  const query = gql`
+    query Query($where: MessagesWhereInput) {
+      findFirstMessages(where: $where) {
+        id
+        messageHash
+        origin
+        destination
+        nonce
+        internalSender
+        internalRecipient
+        msgType
+        root
+        state
+        dispatchBlock
+        dispatchedAt
+        updatedAt
+        relayedAt
+        receivedAt
+        processedAt
+        confirmAt
+        sender
+        recipient
+        amount
+        allowFast
+        detailsHash
+        tokenDomain
+        tokenId
+        body
+        leafIndex
+        tx
+        gasAtDispatch
+        gasAtUpdate
+        gasAtRelay
+        gasAtReceive
+        gasAtProcess
+        sent
+        updated
+        relayed
+        received
+        processed
+        createdAt
+      }
+    }`
+  return await request(`${nomadAPI}graphql`, query, variables).then(
+    async (res) => {
+      // const tx = (await res.data)
+      console.log(`result: ${JSON.stringify(res)}`)
+      return res.findFirstMessages
+    }
+  )
+}

--- a/src/views/Transaction/Nomad/Details.vue
+++ b/src/views/Transaction/Nomad/Details.vue
@@ -81,6 +81,7 @@ import CopyHash from '@/components/CopyHash.vue'
 import StatusHeader from './Header.vue'
 import NotificationError from '@/components/NotificationError.vue'
 import { NetworkName } from '@/config/types'
+import { getTx } from '@/utils/nomadAPI'
 
 interface ComponentData {
   transferMessage: TransferMessage | null
@@ -255,8 +256,7 @@ export default defineComponent({
       const { optimisticSeconds } = networks[this.originNet]
 
       // fetch tx
-      const res = await fetch(`${nomadAPI}${id}`)
-      const tx = (await res.json())[0]
+      const tx = await getTx(id as string)
       console.log('tx data: ', tx)
 
       if (!tx) {


### PR DESCRIPTION
Per Daniil's request, we should be using graphql, not the deprecated api

 - Adds graphql utils file
 - Uses graphql to fetch tx

<img width="635" alt="Screen Shot 2022-06-23 at 10 35 51 AM" src="https://user-images.githubusercontent.com/36751902/175350191-338a299a-d2a7-482d-86f6-acfd91aee450.png">
