### PR TITLE
fix: add missing curly braces

### DIFF
--- a/src/utils/nomadAPI.ts
+++ b/src/utils/nomadAPI.ts
@@ -32,6 +32,8 @@ export async function getUserHistory(
           recipient: {
             equals: address,
           },
+        },
+        {
           sender: {
             equals: address,
           },


### PR DESCRIPTION
We had the OR filter set up with just 1 condition so it was basically acting as an AND, needed to split it up into 2 separate objects.