### PR TITLE
fix: tx history amount from decimals

### DIFF
--- a/src/views/Transactions/Nomad/columns/amount.vue
+++ b/src/views/Transactions/Nomad/columns/amount.vue
@@ -45,13 +45,13 @@ export default defineComponent({
   },
   methods: {
     getAmount() {
-      const { amount, decimals, tokenDomain, tokenId } = this.tx
+      const { amount, tokenDomain, tokenId } = this.tx
       const tokenIdentifier = {
         domain: getNetworkByDomainID(tokenDomain).name,
         id: fromBytes32(tokenId),
       }
       this.token = getTokenByTokenID(tokenIdentifier)!
-      this.amt = toDecimals(BigNumber.from(amount), decimals, 6)
+      this.amt = toDecimals(BigNumber.from(amount), this.token.decimals, 6)
     },
   },
 })


### PR DESCRIPTION
USDC was displaying wrong amount. Looks like there's no decimals field from indexer or maybe it was removed?  Easy fix, use decimals from config