### PR TITLE
feature: filter supported tokens

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,5 +1,4 @@
-import { testnetTokens, mainnetTokens } from './tokens'
-import { getNetworksConfig, getConnextConfig } from '@/utils/config'
+import { getNetworksConfig, getConnextConfig, getTokens } from '@/config/utils'
 
 const {
   VUE_APP_NOMAD_ENVIRONMENT,
@@ -13,8 +12,8 @@ const {
 const environment = VUE_APP_NOMAD_ENVIRONMENT
 
 export const isProduction = environment === 'production'
-export const tokens = isProduction ? mainnetTokens : testnetTokens
-export const networks = getNetworksConfig(tokens)
+export const tokens = getTokens()
+export const networks = getNetworksConfig()
 export const connextConfig = getConnextConfig([VUE_APP_ETHEREUM_RPC])
 export const proofsS3 = VUE_APP_PROOFS_S3
 export const connextScanURL = VUE_APP_CONNEXTSCAN_URL

--- a/src/config/tokenIdentifiers.ts
+++ b/src/config/tokenIdentifiers.ts
@@ -39,14 +39,14 @@ export const testnetTokenIdentifiers: TokenIdentifierMap = {
     domain: 'neontestnet',
     id: '0xf8ad328e98f85fccbf09e43b16dcbbda7e84beab',
   },
-  //   DEV: {
-  //     domain: 'moonbasealpha',
-  //     id: '0x0000000000000000000000000000000000000802',
-  //   },
-  //   wADA: {
-  //   domain: 'milkomedaC1testnet',
-  //   id: '0x65a51E52eCD17B641f8F0D1d56a6c9738951FDC9',
-  //   },
+  DEV: {
+    domain: 'moonbasealpha',
+    id: '0x0000000000000000000000000000000000000802',
+  },
+  wADA: {
+    domain: 'milkomedaC1testnet',
+    id: '0x65a51E52eCD17B641f8F0D1d56a6c9738951FDC9',
+  },
 }
 
 // --- MAINNET TOKEN IDENTIFIERS ---

--- a/src/config/tokens.ts
+++ b/src/config/tokens.ts
@@ -12,8 +12,6 @@ import renBTCIcon from '@/assets/token-logos/renBTC.png'
 import sBTCIcon from '@/assets/token-logos/sBTC.png'
 import tBTCIcon from '@/assets/token-logos/tBTC.png'
 import NEONIcon from '@/assets/token-logos/NEON.svg'
-// import DEVIcon from '@/assets/token-logos/DEV.png'
-// import wADAIcon from '@/assets/token-logos/wADA.png'
 
 // MAINNET TOKEN ICONS
 import wETHIcon from '@/assets/token-logos/WETH.png'
@@ -213,45 +211,43 @@ export const testnetTokens: TokenMetadataMap = {
   //   default: true,
   //   show: true,
   // },
-  // DEV: {
-  //   key: '',
-  //   nativeNetwork: 'moonbasealpha',
-  //   symbol: 'DEV',
-  //   name: 'Moonbase DEV',
-  //   icon: DEVIcon,
-  //   iconColors: ['#53CBC8', '#e84195'],
-  //   decimals: 18,
-  //   coinGeckoId: 'moonbeam',
-  //   tokenIdentifier: null,
-  //   nativeOnly: true,
-  //
-  // },
-  // milkADA: {
-  //   key: '',
-  //   nativeNetwork: 'milkomedaC1testnet',
-  //   symbol: 'mADA',
-  //   name: 'milkADA',
-  //   icon: wADAIcon,
-  //   iconColors: ['#6684CD', '#0033AC'],
-  //   decimals: 18,
-  //   coinGeckoId: 'cardano',
-  //   tokenIdentifier: null,
-  //   nativeOnly: true,
-  //
-  //   wrappedAsset: 'wADA',
-  // },
-  // wADA: {
-  //   key: '',
-  //   nativeNetwork: 'milkomedaC1testnet',
-  //   symbol: 'wADA',
-  //   name: 'wADA',
-  //   icon: wADAIcon,
-  //   iconColors: ['#6684CD', '#0033AC'],
-  //   decimals: 18,
-  //   coinGeckoId: 'cardano',
-  //   tokenIdentifier: testnetTokenIdentifiers.wADA,
-  //   nativeOnly: false,
-  // },
+  DEV: {
+    key: 'DEV',
+    nativeNetwork: 'moonbasealpha',
+    symbol: 'DEV',
+    name: 'Moonbase DEV',
+    icon: DEVIcon,
+    iconColors: ['#53CBC8', '#e84195'],
+    decimals: 18,
+    coinGeckoId: 'moonbeam',
+    tokenIdentifier: null,
+    nativeOnly: true,
+  },
+  milkADA: {
+    key: 'milkADA',
+    nativeNetwork: 'milkomedaC1testnet',
+    symbol: 'mADA',
+    name: 'milkADA',
+    icon: wADAIcon,
+    iconColors: ['#6684CD', '#0033AC'],
+    decimals: 18,
+    coinGeckoId: 'cardano',
+    tokenIdentifier: null,
+    nativeOnly: true,
+    wrappedAsset: 'wADA',
+  },
+  wADA: {
+    key: 'wADA',
+    nativeNetwork: 'milkomedaC1testnet',
+    symbol: 'wADA',
+    name: 'wADA',
+    icon: wADAIcon,
+    iconColors: ['#6684CD', '#0033AC'],
+    decimals: 18,
+    coinGeckoId: 'cardano',
+    tokenIdentifier: testnetTokenIdentifiers.wADA,
+    nativeOnly: false,
+  },
 }
 
 export const mainnetTokens: TokenMetadataMap = {

--- a/src/config/tokens.ts
+++ b/src/config/tokens.ts
@@ -43,7 +43,7 @@ import USDTIcon from '@/assets/token-logos/USDT.png'
 import USDCIcon from '@/assets/token-logos/USDC.png'
 import DAIIcon from '@/assets/token-logos/DAI.png'
 import EvmosIcon from '@/assets/token-logos/EVMOS.png'
-// import AVAXIcon from '@/assets/token-logos/AVAX.png'
+import AVAXIcon from '@/assets/token-logos/AVAX.png'
 
 export const testnetTokens: TokenMetadataMap = {
   // Only for use with connext in dev environment
@@ -399,31 +399,33 @@ export const mainnetTokens: TokenMetadataMap = {
     tokenIdentifier: mainnetTokenIdentifiers.DAI,
     nativeOnly: false,
   },
-  // AVAX: {
-  //   nativeNetwork: 'avalanche',
-  //   symbol: 'AVAX',
-  //   name: 'Avalanche',
-  //   icon: AVAXIcon,
-  //   iconColors: ['#fff', '#e84142'],
-  //   decimals: 18,
-  //   coinGeckoId: 'avalanche',
-  //   tokenIdentifier: null,
-  //   nativeOnly: true,
-  //   minAmt: 10,
-  //   wrappedAsset: 'wAVAX',
-  // },
-  // wAVAX: {
-  //   nativeNetwork: 'avalanche',
-  //   symbol: 'wAVAX',
-  //   name: 'Wrapped AVAX',
-  //   icon: AVAXIcon,
-  //   iconColors: ['#fff', '#e84142'],
-  //   decimals: 18,
-  //   coinGeckoId: 'wrapped-avax',
-  //   tokenIdentifier: mainnetTokenIdentifiers.wAVAX,
-  //   nativeOnly: false,
-  //   minAmt: 10,
-  // },
+  AVAX: {
+    key: 'AVAX',
+    nativeNetwork: 'avalanche',
+    symbol: 'AVAX',
+    name: 'Avalanche',
+    icon: AVAXIcon,
+    iconColors: ['#fff', '#e84142'],
+    decimals: 18,
+    coinGeckoId: 'avalanche',
+    tokenIdentifier: null,
+    nativeOnly: true,
+    wrappedAsset: 'wAVAX',
+    hide: true
+  },
+  wAVAX: {
+    key: 'AVAX',
+    nativeNetwork: 'avalanche',
+    symbol: 'wAVAX',
+    name: 'Wrapped AVAX',
+    icon: AVAXIcon,
+    iconColors: ['#fff', '#e84142'],
+    decimals: 18,
+    coinGeckoId: 'wrapped-avax',
+    tokenIdentifier: mainnetTokenIdentifiers.wAVAX,
+    nativeOnly: false,
+    hide: true
+  },
   FRAX: {
     key: 'FRAX',
     nativeNetwork: 'ethereum',

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -18,6 +18,7 @@ export type TokenMetadata = {
   tokenIdentifier: TokenIdentifier | null
   nativeOnly: boolean
   wrappedAsset?: string
+  hide?: boolean
 }
 
 export type NetworkMetadata = {

--- a/src/config/utils.ts
+++ b/src/config/utils.ts
@@ -1,5 +1,7 @@
 import { SdkBaseChainConfigParams } from '@connext/nxtp-sdk'
 import { NetworkMetadata, NetworkMap, TokenMetadataMap } from '@/config/types'
+import { testnetTokens, mainnetTokens } from './tokens'
+import { isProduction } from '.'
 import AVAXIcon from '@/assets/token-logos/AVAX.png'
 
 export const config = await import('@nomad-xyz/sdk-bridge').then(
@@ -46,6 +48,8 @@ const rpcs: { [key: string]: string[] } = {
   avalanche: [VUE_APP_AVALANCHE_RPC],
 }
 
+const tokenMap: TokenMetadataMap = isProduction ? mainnetTokens : testnetTokens
+
 export const getConnextConfig = (
   ethereumRPCs: string[]
 ): SdkBaseChainConfigParams => {
@@ -71,13 +75,13 @@ export const getConnextConfig = (
   return connextConfig
 }
 
-export const getNetworksConfig = (tokens: TokenMetadataMap): NetworkMap => {
+export const getNetworksConfig = (): NetworkMap => {
   const networks: NetworkMap = {}
 
   Object.keys(config.bridgeGui).forEach((networkName) => {
     const { displayName, nativeTokenSymbol, connections, manualProcessing } =
       config.bridgeGui[networkName]
-    const nativeToken = tokens[nativeTokenSymbol]
+    const nativeToken = tokenMap[nativeTokenSymbol]
     const { name, domain: domainID } = config.protocol.networks[networkName]
     const { chainId: chainID, blockExplorer } =
       config.protocol.networks[networkName].specs
@@ -109,4 +113,15 @@ export const getNetworksConfig = (tokens: TokenMetadataMap): NetworkMap => {
   }
 
   return networks
+}
+
+export const getTokens  = (): TokenMetadataMap => {
+  const supported: TokenMetadataMap = {}
+  for (const k of Object.keys(tokenMap)) {
+    const token = tokenMap[k]
+    if (config.networks.includes(token.nativeNetwork)) {
+      supported[k] = token
+    }
+  }
+  return supported
 }

--- a/src/config/utils.ts
+++ b/src/config/utils.ts
@@ -1,8 +1,10 @@
 import { SdkBaseChainConfigParams } from '@connext/nxtp-sdk'
 import { NetworkMetadata, NetworkMap, TokenMetadataMap } from '@/config/types'
 import { testnetTokens, mainnetTokens } from './tokens'
-import { isProduction } from '.'
-import AVAXIcon from '@/assets/token-logos/AVAX.png'
+
+const environment = process.env.VUE_APP_NOMAD_ENVIRONMENT
+const isProduction = environment === 'production'
+const tokenMap: TokenMetadataMap = isProduction ? mainnetTokens : testnetTokens
 
 export const config = await import('@nomad-xyz/sdk-bridge').then(
   async ({ BridgeContext }) => {
@@ -47,8 +49,6 @@ const rpcs: { [key: string]: string[] } = {
   evmostestnet: [VUE_APP_EVMOS_TESTNET_RPC],
   avalanche: [VUE_APP_AVALANCHE_RPC],
 }
-
-const tokenMap: TokenMetadataMap = isProduction ? mainnetTokens : testnetTokens
 
 export const getConnextConfig = (
   ethereumRPCs: string[]
@@ -107,11 +107,6 @@ export const getNetworksConfig = (): NetworkMap => {
     } as NetworkMetadata
   })
 
-  // Add avalanche icon because it doesn't have native asset listed
-  if (networks.avalanche) {
-    networks.avalanche.icon = AVAXIcon
-  }
-
   return networks
 }
 
@@ -119,7 +114,7 @@ export const getTokens  = (): TokenMetadataMap => {
   const supported: TokenMetadataMap = {}
   for (const k of Object.keys(tokenMap)) {
     const token = tokenMap[k]
-    if (config.networks.includes(token.nativeNetwork)) {
+    if (!token.hide && config.networks.includes(token.nativeNetwork)) {
       supported[k] = token
     }
   }

--- a/src/views/Transfer/Input/Input.main.vue
+++ b/src/views/Transfer/Input/Input.main.vue
@@ -1,6 +1,6 @@
 <template>
   <!-- BRIDGE TOKENS card -->
-  <div>
+  <div class="w-full">
     <!-- color blur section -->
     <div class="bridge">
       <bg-blur class="absolute inset-0 w-full h-full z-negative" />


### PR DESCRIPTION
Shows only tokens on supported networks.  Allows us to add tokens for soon-to-be-deployed tokens so that everything is set up as soon as the config is updated